### PR TITLE
feat: [NON-JIRA] parameterize file to copy in docker build files

### DIFF
--- a/address-profiling-coefficient-pipeline/initial_load_adapter/Dockerfile
+++ b/address-profiling-coefficient-pipeline/initial_load_adapter/Dockerfile
@@ -1,11 +1,13 @@
 FROM python:3.12
 
+ARG FILENAME
+
 WORKDIR /app
 
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
-COPY ./address_profiling_2024-12-13_115731.csv .
+COPY ${FILENAME} .
 COPY ./producer.py .
 
 CMD ["python", "./producer.py"]

--- a/iow-uprn-lat-log-coefficient-pipeline/adapter/Dockerfile
+++ b/iow-uprn-lat-log-coefficient-pipeline/adapter/Dockerfile
@@ -1,11 +1,13 @@
 FROM python:3.12
 
+ARG FILENAME
+
 WORKDIR /app
 
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
-COPY ./uprn-lat-long.csv .
+COPY ${FILENAME} .
 COPY ./producer.py .
 
 CMD ["python", "./producer.py"]


### PR DESCRIPTION
Replaced the hard coded file path with a build argument that can be passed when trying to build the images for both the address profile initial load adapter and the iow uprn lat long adapter.