### PR TITLE
feat(dpav-2079): added publish scripts to the epc mapper and s3 adapter

### DIFF
--- a/address-profiling-pipeline/mapper/infrastructure/publish-image.sh
+++ b/address-profiling-pipeline/mapper/infrastructure/publish-image.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+TAG="latest"
+IMAGE="iris-data-pipeline/epc-mapper:$TAG"
+
+if [ -z "$(docker images -q $IMAGE 2> /dev/null)" ]; then
+  echo "Image: $IMAGE does not exist, exiting..."
+  exit 1
+fi
+
+AWS_REGION=eu-west-2
+AWS_ACCOUNT=$(aws sts get-caller-identity --query Account --output text)
+
+aws ecr get-login-password --region $AWS_REGION | sudo docker login --username AWS --password-stdin $AWS_ACCOUNT.dkr.ecr.$AWS_REGION.amazonaws.com
+
+AWS_IMAGE=$AWS_ACCOUNT.dkr.ecr.$AWS_REGION.amazonaws.com/iris-data-pipeline/epc-mapper:$TAG
+
+sudo docker tag $IMAGE $AWS_IMAGE
+sudo docker push $AWS_IMAGE
+
+echo "Revision tag: $TAG"

--- a/generic-adapter/infrastructure/publish-image-s3.sh
+++ b/generic-adapter/infrastructure/publish-image-s3.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+TAG="latest"
+IMAGE="ia/s3-adapter:$TAG"
+
+if [ -z "$(docker images -q $IMAGE 2> /dev/null)" ]; then
+  echo "Image: $IMAGE does not exist, exiting..."
+  exit 1
+fi
+
+AWS_REGION=eu-west-2
+AWS_ACCOUNT=$(aws sts get-caller-identity --query Account --output text)
+
+aws ecr get-login-password --region $AWS_REGION | sudo docker login --username AWS --password-stdin $AWS_ACCOUNT.dkr.ecr.$AWS_REGION.amazonaws.com
+
+AWS_IMAGE=$AWS_ACCOUNT.dkr.ecr.$AWS_REGION.amazonaws.com/ia/s3-adapter:$TAG
+
+sudo docker tag $IMAGE $AWS_IMAGE
+sudo docker push $AWS_IMAGE
+
+echo "Revision tag: $TAG"


### PR DESCRIPTION
## Sensitive Credential Checks
- [x] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [ ] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
There was no process to publish images to AWS for the following python scripts:
- address profiling mapper
- s3 adapter

## Description
<!--- Describe your changes in detail -->
- Added scripts to publish locally built image for both the address profiling mapper and the s3 adapter to AWS

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran. -->
<!--- How does your change affect other areas of the code, etc. -->
Can be tested once changes for the infra are deployed in [this](https://github.com/National-Digital-Twin/ndtp-application-infrastructure/pull/110) PR

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [x] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.