### PR TITLE
bugfix(non-req): added log level variable to configure the logging of the address profiling mapper

### DIFF
--- a/address-profiling-pipeline/mapper/src/mapper.py
+++ b/address-profiling-pipeline/mapper/src/mapper.py
@@ -21,7 +21,7 @@
 # All support, maintenance and further development of this code is now the responsibility
 # of the National Digital Twin Programme.
 
-import sys
+import logging
 from json import loads
 from typing import List, Union
 
@@ -83,6 +83,12 @@ DEBUG = config.get(
 MAPPER_SUB_TYPE = config.get(
     "MAPPER_SUB_TYPE", required=True, description="The sub type of the mapper to run"
 )
+LOG_LEVEL = config.get(
+    "LOG_LEVEL",
+    required=False,
+    description="Logging level for the mapper",
+    default="INFO",
+)
 
 kafka_consumer_config = {
     "bootstrap.servers": BOOTSTRAP_SERVERS,
@@ -104,6 +110,11 @@ kafka_producer_config = {
 
 ies = IESTool(data_ns)
 mapping_function = get_mapping_function(MAPPER_SUB_TYPE)
+
+# set log level for external libraries
+logging.getLogger("ies_tool.ies_tool").setLevel(LOG_LEVEL)
+logging.getLogger("telicent_lib").setLevel(LOG_LEVEL)
+logging.getLogger("telicent_lib.config").setLevel(LOG_LEVEL)
 
 
 def unwrap_and_map(record: Record) -> Union[Record, List[Record], None]:


### PR DESCRIPTION
## Sensitive Credential Checks
- [x] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [ ] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Currently the external libraries used within the address profiling mapper are adding too many logs which is causing any automated workflows to fail due to running out of storage when capturing logs.

## Description
<!--- Describe your changes in detail -->
Added code to capture the log level through an environment variable and then setting the logger for external libraries with this log level for the address profiling mapper.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran. -->
<!--- How does your change affect other areas of the code, etc. -->
Tested locally using local epc taskflow in airflow

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [x] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.