### PR TITLE
feat(dpav-2075): add cross environment kafka adapter

### DIFF
--- a/generic-adapter/Makefile
+++ b/generic-adapter/Makefile
@@ -3,3 +3,12 @@ docker-build:
 
 docker-run:
 	docker run -d --name generic-adapter -e BOOTSTRAP_SERVERS=localhost:9092 -e SASL_USERNAME=${SASL_USERNAME} -e SASL_PASSWORD=${SASL_PASSWORD} -e PRODUCER_NAME=${PRODUCER_NAME} -e SOURCE_NAME=epc -e TARGET_TOPIC=${TARGET_TOPIC} -e FILENAME=${FILE_NAME} -e LIMIT=0 --network "host" generic-adapter
+
+docker-build-kafka-adapter:
+	docker build -t ${IMAGE_TAG} -f infrastructure/Dockerfile.kafka .
+
+docker-run-kafka-adapter:
+	docker run \
+		--mount type=bind,src="$(PWD)/config/${TOPIC_MAPPINGS_FILENAME}",dst=/app/topic_mappings.json,ro \
+		--env-file .env \
+		${IMAGE_TAG}

--- a/generic-adapter/README.md
+++ b/generic-adapter/README.md
@@ -76,13 +76,13 @@ In this example, this is the topic mappings JSON we will use (stored locally in 
 `
 {
   "topic_mappings": [
-    {"source":"address-profiling-test-2026-01-06-154543-epc-assessment-mapped", "target":"knowledge2-geo-test"},
-    {"source":"address-profiling-test-2026-01-06-154543-floor-mapped", "target":"knowledge2-geo-test"},
-    {"source":"address-profiling-test-2026-01-06-154543-heating-mapped", "target":"heating-v2"},
-    {"source":"address-profiling-test-2026-01-06-154543-roof-mapped", "target":"knowledge2-geo-test"},
-    {"source":"address-profiling-test-2026-01-06-154543-structure-unit-mapped", "target":"knowledge2-geo-test"},
-    {"source":"address-profiling-test-2026-01-06-154543-wall-mapped", "target":"knowledge2-geo-test"},
-    {"source":"address-profiling-test-2026-01-06-154543-window-mapped", "target":"knowledge2-geo-test"}
+    {"source_topic":"address-profiling-test-2026-01-06-154543-epc-assessment-mapped", "target_topic":"knowledge2-geo-test"},
+    {"source_topic":"address-profiling-test-2026-01-06-154543-floor-mapped", "target_topic":"knowledge2-geo-test"},
+    {"source_topic":"address-profiling-test-2026-01-06-154543-heating-mapped", "target_topic":"heating-v2"},
+    {"source_topic":"address-profiling-test-2026-01-06-154543-roof-mapped", "target_topic":"knowledge2-geo-test"},
+    {"source_topic":"address-profiling-test-2026-01-06-154543-structure-unit-mapped", "target_topic":"knowledge2-geo-test"},
+    {"source_topic":"address-profiling-test-2026-01-06-154543-wall-mapped", "target_topic":"knowledge2-geo-test"},
+    {"source_topic":"address-profiling-test-2026-01-06-154543-window-mapped", "target_topic":"knowledge2-geo-test"}
   ]
 }
 `

--- a/generic-adapter/README.md
+++ b/generic-adapter/README.md
@@ -17,7 +17,7 @@ to a target Kafka topic. Currently the generic adapter has three modes of operat
 - While in this directory:
   - Run the command `docker build -t <image-tag> -f infrastructure/Dockerfile .` to build the image to bundle the image with the source file.
   - Run the command `docker build -t <image-tag> -f infrastructure/Dockerfile.s3 .` to build the image to use an s3 source.
-  - Run the command `docker build -t <image-tag> -f infrastructure/Dockerfile.kafka .` to build the image for a Kafka topic source.
+  - Run the command `docker build -t <image-tag> -f infrastructure/Dockerfile.kafka .` to build the image for a Kafka topic source. You can also use the supplied Makefile to build and run the Kafka adapter.
 
 ## Running locally
 
@@ -37,18 +37,66 @@ to a target Kafka topic. Currently the generic adapter has three modes of operat
   - SOURCE_NAME: The name of the source that is being adapted (required)
   - PRODUCER_NAME: The name of the adapter instance that is going to adapt the source file to the target topic (required)
 
-To run the Kafka-to-Kafka adapter, you only need these variables defined:
-  - BOOTSTRAP_SERVERS
-  - KAFKA_SECURITY_PROTOCOL (optional, defaults to "SASL_PLAINTEXT")
-  - KAFKA_SASL_MECHANISM (optional, defaults to "PLAIN")
-  - SASL_USERNAME
-  - SASL_PASSWORD
-  - TOPIC_MAPPINGS_FILEPATH: the filepath of the topic mappings JSON file within the container (alternative is for this to be supplied via Airflow UI). The JSON value itself must be in this format:
+You can run the Kafka-to-Kafka adapter broadly in two ways: to move data within the same Kafka cluster or between Kafka clusters. For the first, you need these variables defined as a minimum:
+  - SOURCE_BOOTSTRAP_SERVERS
+  - SOURCE_KAFKA_SECURITY_PROTOCOL (optional, defaults to "SASL_PLAINTEXT")
+  - SOURCE_KAFKA_SASL_MECHANISM (optional, defaults to "PLAIN")
+  - SOURCE_SASL_USERNAME
+  - SOURCE_SASL_PASSWORD
+
+If you'd like to move data between Kafka clusters, then you also need environment variables which allow the adapter to connect to that cluster:
+  - TARGET_BOOTSTRAP_SERVERS
+  - TARGET_KAFKA_SECURITY_PROTOCOL (optional, defaults to "SASL_PLAINTEXT")
+  - TARGET_KAFKA_SASL_MECHANISM (optional, defaults to "PLAIN")
+  - TARGET_SASL_USERNAME
+  - TARGET_SASL_PASSWORD
+
+Regardless of the above, you also need to tell the Kafka adapter what data you'd like to move and where (in terms of Kafka topics). You can do that by either mounting a topic_mappings.json file to the container or by passing in an TOPIC_MAPPINGS_JSON env variable at runtime. The JSON must be in this format:
 `
   {
   "topic_mappings": [
-    {"source":"", "source_topic_group_id": "", "target":""},
-    {"source":"", "source_topic_group_id": "", "target":""}
+    {"source":"", "target":""},
+    {"source":"", "target":""}
   ]
 }
 `
+
+If you'd like to run the Kafka adapter locally and need a second Kafka and ZooKeeper instance to test the movement of data between clusters, then you can do this easily by running `docker compose up -d` from the generic-adapter/infrastructure directory. Server details for the "kafka-b" instance are in generic-adapter/infrastructure/kafka-b/server.properties file.
+
+### EXAMPLE using Kafka adapter within same cluster
+
+To use the adapter within the same cluster, set SOURCE_ variables only in your .env as so:
+`
+SOURCE_BOOTSTRAP_SERVERS=172.30.95.127:9092
+SOURCE_SASL_USERNAME=user1
+SOURCE_SASL_PASSWORD=root
+`
+
+In this example, this is the topic mappings JSON we will use (stored locally in config/topic_mappings-single-cluster.json):
+`
+{
+  "topic_mappings": [
+    {"source":"address-profiling-test-2026-01-06-154543-epc-assessment-mapped", "target":"knowledge2-geo-test"},
+    {"source":"address-profiling-test-2026-01-06-154543-floor-mapped", "target":"knowledge2-geo-test"},
+    {"source":"address-profiling-test-2026-01-06-154543-heating-mapped", "target":"heating-v2"},
+    {"source":"address-profiling-test-2026-01-06-154543-roof-mapped", "target":"knowledge2-geo-test"},
+    {"source":"address-profiling-test-2026-01-06-154543-structure-unit-mapped", "target":"knowledge2-geo-test"},
+    {"source":"address-profiling-test-2026-01-06-154543-wall-mapped", "target":"knowledge2-geo-test"},
+    {"source":"address-profiling-test-2026-01-06-154543-window-mapped", "target":"knowledge2-geo-test"}
+  ]
+}
+`
+
+We can now build the image using
+`
+make docker-build-kafka-adapter IMAGE_TAG="kafka-adapter:latest"
+`
+
+This creates an image called kafka-adapter:latest. We can then run the image as a container with:
+
+`
+make docker-run-kafka-adapter TOPIC_MAPPINGS_FILENAME="topic_mappings-single-cluster.json" IMAGE_TAG=kafka-adapter:latest
+`
+
+This will trigger the movement of data from the source topics to the target topics defined in the JSON and within the same Kafka cluster as defined in the .env file.
+

--- a/generic-adapter/README.md
+++ b/generic-adapter/README.md
@@ -55,8 +55,8 @@ Regardless of the above, you also need to tell the Kafka adapter what data you'd
 `
   {
   "topic_mappings": [
-    {"source":"", "target":""},
-    {"source":"", "target":""}
+    {"source_topic":"", "target_topic":""},
+    {"source_topic":"", "target_topic":""}
   ]
 }
 `

--- a/generic-adapter/infrastructure/Dockerfile.kafka
+++ b/generic-adapter/infrastructure/Dockerfile.kafka
@@ -9,11 +9,12 @@ COPY requirements-kafka.txt .
 RUN pip install --no-cache-dir -r requirements-kafka.txt
 
 COPY src/kafka_producer.py .
-COPY config/topic_mappings.json .
 
 USER adapteruser
 
 ENV PYTHONUNBUFFERED=1
 ENV PYTHONPATH=/app
+
+ENV TOPIC_MAPPINGS_FILEPATH=/app/topic_mappings.json
 
 CMD ["python", "./kafka_producer.py"]

--- a/generic-adapter/infrastructure/docker-compose.yml
+++ b/generic-adapter/infrastructure/docker-compose.yml
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# © Crown Copyright 2025. This work has been developed by the National Digital Twin Programme and is legally attributed to the Department for Business and Trade (UK) as the governing entity.
+
 services:
   zookeeper:
     container_name: zookeeper-b

--- a/generic-adapter/infrastructure/docker-compose.yml
+++ b/generic-adapter/infrastructure/docker-compose.yml
@@ -1,0 +1,31 @@
+services:
+  zookeeper:
+    container_name: zookeeper-b
+    image: bitnami/zookeeper:latest
+    ports:
+      - "2182:2181"
+    environment:
+      - ALLOW_ANONYMOUS_LOGIN=yes
+    networks: 
+      - network_b
+  kafka:
+    container_name: kafka-b
+    image: "bitnamilegacy/kafka:3.6.0"
+    depends_on:
+      - zookeeper
+    ports:
+      - "9093:9092"
+    volumes:
+      - ./kafka-b/server.properties:/bitnami/kafka/config/server.properties
+      - ./kafka-b/producer.properties:/bitnami/kafka/config/producer.properties
+      - ./kafka-b/consumer.properties:/bitnami/kafka/config/consumer.properties
+    environment:
+      - BITNAMI_DEBUG=true
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    networks: 
+      - network_b
+  
+networks:
+  network_b:
+    name: kafka_b_net

--- a/generic-adapter/infrastructure/kafka-b/consumer.properties
+++ b/generic-adapter/infrastructure/kafka-b/consumer.properties
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+# © Crown Copyright 2025. This work has been developed by the National Digital Twin Programme and is legally attributed to the Department for Business and Trade (UK) as the governing entity.
+
+security.protocol=SASL_PLAINTEXT
+sasl.mechanism=PLAIN
+sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required \
+    username="user1" \
+    password="root";

--- a/generic-adapter/infrastructure/kafka-b/producer.properties
+++ b/generic-adapter/infrastructure/kafka-b/producer.properties
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+# © Crown Copyright 2025. This work has been developed by the National Digital Twin Programme and is legally attributed to the Department for Business and Trade (UK) as the governing entity.
+
+security.protocol=SASL_PLAINTEXT
+sasl.mechanism=PLAIN
+sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required \
+    username="user1" \
+    password="root";

--- a/generic-adapter/infrastructure/kafka-b/server.properties
+++ b/generic-adapter/infrastructure/kafka-b/server.properties
@@ -3,7 +3,7 @@
 
 # Listeners configuration
 listeners=CLIENT://:9092,INTERNAL://:9094,CONTROLLER://:9093
-advertised.listeners=CLIENT://172.30.95.127:9093,INTERNAL://kafka-b:9094
+advertised.listeners=CLIENT://<client-ip>:9093,INTERNAL://kafka-b:9094
 listener.security.protocol.map=CLIENT:SASL_PLAINTEXT,INTERNAL:SASL_PLAINTEXT,CONTROLLER:SASL_PLAINTEXT
 inter.broker.listener.name=INTERNAL
 # Zookeeper config

--- a/generic-adapter/infrastructure/kafka-b/server.properties
+++ b/generic-adapter/infrastructure/kafka-b/server.properties
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: Apache-2.0
+# © Crown Copyright 2025. This work has been developed by the National Digital Twin Programme and is legally attributed to the Department for Business and Trade (UK) as the governing entity.
+
+# Listeners configuration
+listeners=CLIENT://:9092,INTERNAL://:9094,CONTROLLER://:9093
+advertised.listeners=CLIENT://172.30.95.127:9093,INTERNAL://kafka-b:9094
+listener.security.protocol.map=CLIENT:SASL_PLAINTEXT,INTERNAL:SASL_PLAINTEXT,CONTROLLER:SASL_PLAINTEXT
+inter.broker.listener.name=INTERNAL
+# Zookeeper config
+broker.id=0
+zookeeper.connect=zookeeper-b:2181
+# controller.listener.names=CONTROLLER
+controller.quorum.voters=0@kafka-b:9093
+# Common Kafka Configuration
+offsets.topic.replication.factor=1
+sasl.enabled.mechanisms=PLAIN,SCRAM-SHA-256,SCRAM-SHA-512
+# Kraft Controller listener SASL settings
+sasl.mechanism.controller.protocol=PLAIN
+listener.name.controller.sasl.enabled.mechanisms=PLAIN
+listener.name.controller.plain.sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username="admin" password="root" user_admin="root";
+# Kafka data logs directory
+log.dir=/bitnami/kafka/data
+# Kafka application logs directory
+logs.dir=/opt/bitnami/kafka/logs
+
+# Interbroker configuration
+inter.broker.listener.name=INTERNAL
+sasl.mechanism.inter.broker.protocol=PLAIN
+listener.name.internal.plain.sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username="admin" password="root" user_admin="root" user_user1=root;
+listener.name.internal.scram-sha-256.sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username="admin" password="root" user_admin="root";
+listener.name.internal.scram-sha-512.sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username="admin" password="root" user_admin="root";
+# Listeners SASL JAAS configuration
+listener.name.client.plain.sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required user_user1="root";
+listener.name.client.scram-sha-256.sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required;
+listener.name.client.scram-sha-512.sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required;

--- a/generic-adapter/src/kafka_producer.py
+++ b/generic-adapter/src/kafka_producer.py
@@ -25,6 +25,7 @@ import json
 import logging
 import time
 from typing import List, Tuple
+import re
 
 from confluent_kafka import Consumer, KafkaError, Producer
 from dotenv import load_dotenv
@@ -133,6 +134,7 @@ PROGRESS_LOG_INTERVAL = int(os.getenv(
     "PROGRESS_LOG_INTERVAL",
     default=25000,
 ))
+SAFE_RE = re.compile(r"[^0-9A-Za-z]+")
 
 _EXIT = object()
 
@@ -271,26 +273,22 @@ def run_mapping(source_topic: str, group_id: str, target_topic: str) -> None:
         processed,
     )
 
-def _safe(s: str) -> str:
-    return s.replace(":", "_").replace(".", "_").replace(",", "_")
-
 for mapping in topic_mappings["topic_mappings"]:
     source_topic = mapping["source_topic"]
     target_topic = mapping["target_topic"]
 
-    ## TODO: replace SOURCE_BROKER and TARGET_BROKER with env variables to be passed in
     if SOURCE_BROKER != TARGET_BROKER:
         source_topic_group_id = (
             f"{source_topic}__to__{target_topic}"
-            f"__src__{_safe(SOURCE_ENV_NAME)}__tgt__{_safe(TARGET_ENV_NAME)}"
+            f"__src__{SAFE_RE.sub("_", SOURCE_ENV_NAME)}__tgt__{SAFE_RE.sub("_", TARGET_ENV_NAME)}"
         )
     else:
         source_topic_group_id = (
             f"{source_topic}__to__{target_topic}"
         )
     
-    if SOURCE_BROKER == TARGET_BROKER and source_topic == target_topic:
-        raise ValueError(f"Refusing to copy {source_topic} to itself on the same cluster.")
+        if source_topic == target_topic:
+            raise ValueError(f"Refusing to copy {source_topic} to itself on the same cluster.")
 
     run_mapping(
         source_topic,

--- a/generic-adapter/src/kafka_producer.py
+++ b/generic-adapter/src/kafka_producer.py
@@ -72,7 +72,7 @@ TARGET_BROKER = os.getenv(
 )
 
 if not TARGET_BROKER:
-    logger.info(f"TARGET_BOOTSTRAP_SERVERS not supplied, target Kafka broker will be set to the source Kafka broker.")
+    logger.info("TARGET_BOOTSTRAP_SERVERS not supplied, target Kafka broker will be set to the source Kafka broker.")
 
     TARGET_BROKER=SOURCE_BROKER
     TARGET_SASL_USERNAME=SOURCE_SASL_USERNAME

--- a/generic-adapter/src/kafka_producer.py
+++ b/generic-adapter/src/kafka_producer.py
@@ -34,46 +34,105 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 load_dotenv()
-BROKER = os.getenv(
-    "BOOTSTRAP_SERVERS",
-    default=True,
-)
-SASL_USERNAME = os.getenv(
-    "SASL_USERNAME",
+SOURCE_BROKER = os.getenv(
+    "SOURCE_BOOTSTRAP_SERVERS",
     default=None,
 )
-SASL_PASSWORD = os.getenv(
-    "SASL_PASSWORD",
+
+if not SOURCE_BROKER:
+    raise ValueError("SOURCE_BOOTSTRAP_SERVERS is required.")
+
+SOURCE_SASL_USERNAME = os.getenv(
+    "SOURCE_SASL_USERNAME",
     default=None,
 )
-KAFKA_SECURITY_PROTOCOL = os.getenv(
-    "KAFKA_SECURITY_PROTOCOL",
+SOURCE_SASL_PASSWORD = os.getenv(
+    "SOURCE_SASL_PASSWORD",
+    default=None,
+)
+SOURCE_KAFKA_SECURITY_PROTOCOL = os.getenv(
+    "SOURCE_KAFKA_SECURITY_PROTOCOL",
     default="SASL_PLAINTEXT",
 )
-KAFKA_SASL_MECHANISM = os.getenv(
-    "KAFKA_SASL_MECHANISM",
+SOURCE_KAFKA_SASL_MECHANISM = os.getenv(
+    "SOURCE_KAFKA_SASL_MECHANISM",
     default="PLAIN",
 )
+
+logger.info(
+    "Source broker params: " \
+    f"SOURCE_BROKER: {SOURCE_BROKER} "
+    f"SOURCE_KAFKA_SECURITY_PROTOCOL: {SOURCE_KAFKA_SECURITY_PROTOCOL} "
+    f"SOURCE_KAFKA_SASL_MECHANISM: {SOURCE_KAFKA_SASL_MECHANISM} "
+)
+
+TARGET_BROKER = os.getenv(
+    "TARGET_BOOTSTRAP_SERVERS",
+    default=None,
+)
+
+if not TARGET_BROKER:
+    logger.info(f"TARGET_BOOTSTRAP_SERVERS not supplied, target Kafka broker will be set to the source Kafka broker.")
+
+    TARGET_BROKER=SOURCE_BROKER
+    TARGET_SASL_USERNAME=SOURCE_SASL_USERNAME
+    TARGET_SASL_PASSWORD=SOURCE_SASL_PASSWORD
+    TARGET_KAFKA_SECURITY_PROTOCOL=SOURCE_KAFKA_SECURITY_PROTOCOL
+    TARGET_KAFKA_SASL_MECHANISM=SOURCE_KAFKA_SASL_MECHANISM
+    
+else:
+    SOURCE_ENV_NAME = os.getenv(
+        "SOURCE_ENV_NAME",
+        default=None
+    )
+    TARGET_ENV_NAME = os.getenv(
+        "TARGET_ENV_NAME",
+        default=None
+    )
+    TARGET_SASL_USERNAME = os.getenv(
+        "TARGET_SASL_USERNAME",
+        default=None,
+    )
+    TARGET_SASL_PASSWORD = os.getenv(
+        "TARGET_SASL_PASSWORD",
+        default=None,
+    )
+    TARGET_KAFKA_SECURITY_PROTOCOL = os.getenv(
+        "TARGET_KAFKA_SECURITY_PROTOCOL",
+        default="SASL_PLAINTEXT",
+    )
+    TARGET_KAFKA_SASL_MECHANISM = os.getenv(
+        "TARGET_KAFKA_SASL_MECHANISM",
+        default="PLAIN",
+    )
+
+    logger.info(
+        "Target broker params: " \
+        f"TARGET_BROKER: {TARGET_BROKER} "
+        f"TARGET_KAFKA_SECURITY_PROTOCOL: {TARGET_KAFKA_SECURITY_PROTOCOL} "
+        f"TARGET_KAFKA_SASL_MECHANISM: {TARGET_KAFKA_SASL_MECHANISM} "
+    )
+
 AUTO_OFFSET_RESET = os.getenv(
     "AUTO_OFFSET_RESET",
     default="earliest",
 )
-POLL_TIMEOUT_SECONDS = os.getenv(
+POLL_TIMEOUT_SECONDS = float(os.getenv(
     "POLL_TIMEOUT_SECONDS",
     default=1.0,
-)
-IDLE_TIMEOUT_SECONDS = os.getenv(
+))
+IDLE_TIMEOUT_SECONDS = float(os.getenv(
     "IDLE_TIMEOUT_SECONDS",
     default=10,
-)
-COMMIT_INTERVAL = os.getenv(
+))
+COMMIT_INTERVAL = int(os.getenv(
     "COMMIT_INTERVAL",
     default=1000,
-)
-PROGRESS_LOG_INTERVAL = os.getenv(
+))
+PROGRESS_LOG_INTERVAL = int(os.getenv(
     "PROGRESS_LOG_INTERVAL",
     default=25000,
-)
+))
 
 _EXIT = object()
 
@@ -82,7 +141,7 @@ topic_mappings_json = os.getenv("TOPIC_MAPPINGS_JSON", default=None)
 if topic_mappings_json:
     topic_mappings = json.loads(topic_mappings_json)
 else:
-    logging.info("Topic mappings not provided through Airflow config, falling back to JSON file inside container.")
+    logging.info("Topic mappings not provided through Airflow config, falling back to JSON file mounted to the container.")
     
     TOPIC_MAPPINGS_FILEPATH = os.getenv("TOPIC_MAPPINGS_FILEPATH", default=None)
     with open(TOPIC_MAPPINGS_FILEPATH, "r", encoding="utf-8") as f:
@@ -97,11 +156,11 @@ def _merge_headers(headers: List[Tuple[str, bytes | str]] | None, source_topic: 
 
 def _build_consumer_cfg(group_id: str) -> dict:
     return {
-        "bootstrap.servers": BROKER,
-        "security.protocol": KAFKA_SECURITY_PROTOCOL,
-        "sasl.mechanism": KAFKA_SASL_MECHANISM,
-        "sasl.username": SASL_USERNAME,
-        "sasl.password": SASL_PASSWORD,
+        "bootstrap.servers": SOURCE_BROKER,
+        "security.protocol": SOURCE_KAFKA_SECURITY_PROTOCOL,
+        "sasl.mechanism": SOURCE_KAFKA_SASL_MECHANISM,
+        "sasl.username": SOURCE_SASL_USERNAME,
+        "sasl.password": SOURCE_SASL_PASSWORD,
         "group.id": group_id,
         "auto.offset.reset": AUTO_OFFSET_RESET,
         "enable.auto.commit": False,
@@ -110,11 +169,11 @@ def _build_consumer_cfg(group_id: str) -> dict:
 
 def _build_producer_cfg() -> dict:
     return {
-        "bootstrap.servers": BROKER,
-        "security.protocol": KAFKA_SECURITY_PROTOCOL,
-        "sasl.mechanism": KAFKA_SASL_MECHANISM,
-        "sasl.username": SASL_USERNAME,
-        "sasl.password": SASL_PASSWORD,
+        "bootstrap.servers": TARGET_BROKER,
+        "security.protocol": TARGET_KAFKA_SECURITY_PROTOCOL,
+        "sasl.mechanism": TARGET_KAFKA_SASL_MECHANISM,
+        "sasl.username": TARGET_SASL_USERNAME,
+        "sasl.password": TARGET_SASL_PASSWORD,
         "allow.auto.create.topics": True
     }
 
@@ -191,10 +250,13 @@ def run_mapping(source_topic: str, group_id: str, target_topic: str) -> None:
 
         if PROGRESS_LOG_INTERVAL > 0 and processed % PROGRESS_LOG_INTERVAL == 0:
             logger.info("Processed %d records from %s", processed, source_topic)
+            producer.flush()
 
         _commit_if_needed(consumer, processed)
 
-    producer.flush()
+    if processed % PROGRESS_LOG_INTERVAL != 0:
+        producer.flush()
+
     if processed > 0:
         try:
             consumer.commit(asynchronous=False)
@@ -209,10 +271,29 @@ def run_mapping(source_topic: str, group_id: str, target_topic: str) -> None:
         processed,
     )
 
+def _safe(s: str) -> str:
+    return s.replace(":", "_").replace(".", "_").replace(",", "_")
 
 for mapping in topic_mappings["topic_mappings"]:
+    source_topic = mapping["source_topic"]
+    target_topic = mapping["target_topic"]
+
+    ## TODO: replace SOURCE_BROKER and TARGET_BROKER with env variables to be passed in
+    if SOURCE_BROKER != TARGET_BROKER:
+        source_topic_group_id = (
+            f"{source_topic}__to__{target_topic}"
+            f"__src__{_safe(SOURCE_ENV_NAME)}__tgt__{_safe(TARGET_ENV_NAME)}"
+        )
+    else:
+        source_topic_group_id = (
+            f"{source_topic}__to__{target_topic}"
+        )
+    
+    if SOURCE_BROKER == TARGET_BROKER and source_topic == target_topic:
+        raise ValueError(f"Refusing to copy {source_topic} to itself on the same cluster.")
+
     run_mapping(
-        mapping["source"],
-        mapping["source_topic_group_id"],
-        mapping["target"],
+        source_topic,
+        source_topic_group_id,
+        target_topic,
     )


### PR DESCRIPTION
## Sensitive Credential Checks
- [x] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [x] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change improves the kafka adapter so that it can move data within a single cluster or between clusters depending on what is configured in the user's .env file.

<!--- If it fixes an open issue, please link to the issue here. -->

## Description
<!--- Describe your changes in detail -->
Adding in SOURCE and TARGET variables into kafka_producer.py for more control over what environments data is transferred to. Adding protections and defense to handle cases where a SOURCE broker is not defined and where TARGET variables are not defined so that the user is informed of what env variables are present and which are missing. 

Kafka adapter is idempotent in the sense that data cannot be duplicated in the target topic and environment as long as the group ID stays stable.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Tested locally to move data within a Kafka cluster and also between clusters. 

<!--- Include details of your testing environment, and the tests you ran. -->
<!--- How does your change affect other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] It contains only changes required by issue (does not contain other PR)
- [ ] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.