### PR TITLE
bugfix(non-req): removed tag repition in the publish img script for os ngd mapper

### DIFF
--- a/lat-long-pipeline/mapper/infrastructure/publish-image.sh
+++ b/lat-long-pipeline/mapper/infrastructure/publish-image.sh
@@ -13,7 +13,7 @@ AWS_ACCOUNT=$(aws sts get-caller-identity --query Account --output text)
 
 aws ecr get-login-password --region $AWS_REGION | sudo docker login --username AWS --password-stdin $AWS_ACCOUNT.dkr.ecr.$AWS_REGION.amazonaws.com
 
-AWS_IMAGE=$AWS_ACCOUNT.dkr.ecr.$AWS_REGION.amazonaws.com/$IMAGE:$TAG
+AWS_IMAGE=$AWS_ACCOUNT.dkr.ecr.$AWS_REGION.amazonaws.com/$IMAGE
 
 sudo docker tag $IMAGE $AWS_IMAGE
 sudo docker push $AWS_IMAGE


### PR DESCRIPTION
## Sensitive Credential Checks
- [x] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [ ] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The tag for the os ngd address mapper image name in the publish image script which was throwing an error when trying to publish the image to AWS ECR.

## Description
<!--- Describe your changes in detail -->
- Removed the repetition of the tag for the os ngd address mapper in the publish image script

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran. -->
<!--- How does your change affect other areas of the code, etc. -->
Tested locally and pushed image to AWS ECR repo

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [ ] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.