### PR TITLE
feat(non-req): changed publish scripts to add 1 per adapter

### DIFF
--- a/generic-adapter/infrastructure/publish-image-kafka.sh
+++ b/generic-adapter/infrastructure/publish-image-kafka.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 TAG="latest"
-IMAGE="ia/s3-adapter:$TAG"
+IMAGE="data-pipeline-utils/kafka-adapter:$TAG"
 
 if [ -z "$(docker images -q $IMAGE 2> /dev/null)" ]; then
   echo "Image: $IMAGE does not exist, exiting..."

--- a/generic-adapter/src/s3_producer.py
+++ b/generic-adapter/src/s3_producer.py
@@ -124,8 +124,6 @@ kafka_config = {
     "allow.auto.create.topics": True,
 }
 
-csv.field_size_limit(FIELD_SIZE_LIMIT)
-
 
 def create_record(data, security_labels):
     return Record(
@@ -158,6 +156,9 @@ def generate_records() -> Iterable[Record]:
 
     for row in rows:
         yield create_record(row, default_security_label)
+
+
+csv.field_size_limit(FIELD_SIZE_LIMIT)
 
 
 # Create a sink and the adapter


### PR DESCRIPTION
## Sensitive Credential Checks
- [x] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [ ] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The current publish script for the s3 adapter doesnt work unless you specify an image name within the script. Also the only way to publish the kafka adapter image is to modify the IMAGE_NAME within the publish image s3 script.

## Description
<!--- Describe your changes in detail -->
- Updated the publish image s3 script to reference the actual s3 image name
- Created a script for to publish the kafka adapter to AWS.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran. -->
<!--- How does your change affect other areas of the code, etc. -->
Tested locally by running the script to publish the s3 adapter image to AWS ECR.

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [x] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.