### PR TITLE
feat(non-req): changed EPC and OS NGD buildings projectors to run in a batched manner

### DIFF
--- a/address-profiling-pipeline/Makefile
+++ b/address-profiling-pipeline/Makefile
@@ -16,10 +16,10 @@ test-mapper:
 
 docker-build-projector:
 	cp -r ../custom_projectors/ ./projector
-	cp -r ../generic-projector/postgres_projector_template.py ./projector
+	cp -r ../generic-projector/batched_postgres_projector_template.py ./projector
 	docker build -t ${IMAGE_TAG} -f projector/infrastructure/Dockerfile projector
 	rm -rf projector/custom_projectors
-	rm projector/postgres_projector_template.py
+	rm projector/batched_postgres_projector_template.py
 
 docker-run-projector:
 	docker run -d --name address-profiling-projector -e BOOTSTRAP_SERVERS=localhost:9092 -e KAFKA_SECURITY_PROTOCOL=${KAFKA_SECURITY_PROTOCOL} -e KAFKA_SASL_MECHANISM=${KAFKA_SASL_MECHANISM} -e SASL_USERNAME=${SASL_USERNAME} -e SASL_PASSWORD=${SASL_PASSWORD} -e SOURCE_TOPIC=${SOURCE_TOPIC} -e SOURCE_TOPIC_GROUP_ID=${SOURCE_TOPIC_GROUP_ID} -e DB_HOST=${DB_HOST} -e DB_PORT=${DB_PORT} -e DB_NAME=${DB_NAME} -e DB_USERNAME=${DB_USERNAME} -e DB_PASSWORD=${DB_PASSWORD} -e LOG_LEVEL=${LOG_LEVEL} -e DEBUG=${DEBUG} --network "host" ${IMAGE_TAG}

--- a/address-profiling-pipeline/projector/infrastructure/Dockerfile
+++ b/address-profiling-pipeline/projector/infrastructure/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /app
 
 COPY ../custom_projectors ./custom_projectors
 COPY ../src/projection_function.py .
-COPY ../postgres_projector_template.py projector.py
+COPY ../batched_postgres_projector_template.py projector.py
 
 
 COPY ../requirements.txt .

--- a/address-profiling-pipeline/projector/src/projection_function.py
+++ b/address-profiling-pipeline/projector/src/projection_function.py
@@ -17,6 +17,10 @@ EPC_ASSESSMENT_RECORD_EXISTS_QUERY = """
     SELECT * FROM iris.epc_assessment WHERE uprn = :uprn AND lodgement_date = :lodgement_date AND epc_rating = :epc_rating;
 """
 
+EPC_ASSESSMENT_ID_EXISTS_QUERY = """
+    SELECT * FROM iris.epc_assessment WHERE id = :id;
+"""
+
 INSERT_EPC_ASSESSMENT_RECORD_QUERY = """
     INSERT INTO iris.epc_assessment(
         id,
@@ -164,65 +168,107 @@ def get_nullable_value(value: str):
         return value
 
 
-def project_func(connection: Connection, record: dict):
-    uprn = record["UPRN"]
+def project_func(connection: Connection, records: [dict]):
+    records_to_insert = []
+    records_to_insert_seen = set()
 
-    building_record_exists_result = connection.execute(
-        text(BUILDING_RECORD_EXISTS_QUERY), {"uprn": uprn}
-    )
+    for record in records:
+        uprn = record["UPRN"]
 
-    if int(building_record_exists_result.rowcount) == 1:
-        lodgement_date = record["LodgementDate"]
-        epc_rating = record["SAPBand"]
-        epc_assessment_record_exists_result = connection.execute(
-            text(EPC_ASSESSMENT_RECORD_EXISTS_QUERY),
-            {"uprn": uprn, "lodgement_date": lodgement_date, "epc_rating": epc_rating},
+        building_record_exists_result = connection.execute(
+            text(BUILDING_RECORD_EXISTS_QUERY), {"uprn": uprn}
         )
 
-        if int(epc_assessment_record_exists_result.rowcount) == 0:
-            epc_assessment_id = uuid4()
-            epc_assessment_record_params = {
-                "id": str(epc_assessment_id),
-                "uprn": uprn,
-                "epc_rating": epc_rating,
+        if int(building_record_exists_result.rowcount) == 1:
+            lodgement_date = record["LodgementDate"]
+            epc_rating = record["SAPBand"]
+            epc_assessment_record_exists_result = connection.execute(
+                text(EPC_ASSESSMENT_RECORD_EXISTS_QUERY),
+                {
+                    "uprn": uprn,
+                    "lodgement_date": lodgement_date,
+                    "epc_rating": epc_rating,
+                },
+            )
+
+            if int(epc_assessment_record_exists_result.rowcount) == 0:
+                record_foot_print = f"{uprn}|{epc_rating}|{lodgement_date}"
+
+                if record_foot_print in records_to_insert_seen:
+                    continue
+
+                records_to_insert_seen.add(record_foot_print)
+                records_to_insert.append(record)
+
+    epc_assessment_records_params = []
+    structure_unit_records_params = []
+
+    for record_to_insert in records_to_insert:
+        epc_assessment_id = str(uuid4())
+
+        epc_assessment_id_record_result = connection.execute(
+            text(EPC_ASSESSMENT_ID_EXISTS_QUERY), {"id": epc_assessment_id}
+        )
+
+        while int(epc_assessment_id_record_result.rowcount) == 1:
+            epc_assessment_id = str(uuid4())
+            epc_assessment_id_record_result = connection.execute(
+                text(EPC_ASSESSMENT_ID_EXISTS_QUERY), {"id": epc_assessment_id}
+            )
+
+        lodgement_date = record_to_insert["LodgementDate"]
+        epc_assessment_records_params.append(
+            {
+                "id": epc_assessment_id,
+                "uprn": record_to_insert["UPRN"],
+                "epc_rating": record_to_insert["SAPBand"],
                 "lodgement_date": lodgement_date,
-                "sap_rating": record["SAPRating"],
+                "sap_rating": record_to_insert["SAPRating"],
                 "expiry_date": get_expiry_date(lodgement_date),
             }
-            structure_unit_record_params = {
-                "epc_assessment_id": str(epc_assessment_id),
-                "type": get_nullable_value(record["PropertyType"]),
-                "built_form": get_nullable_value(record["BuiltForm"]),
+        )
+        structure_unit_records_params.append(
+            {
+                "epc_assessment_id": epc_assessment_id,
+                "type": get_nullable_value(record_to_insert["PropertyType"]),
+                "built_form": get_nullable_value(record_to_insert["BuiltForm"]),
                 "fuel_type": get_nullable_value(
-                    FUEL_TYPE_MAP.get(record["MainFuelType"])
+                    FUEL_TYPE_MAP.get(record_to_insert["MainFuelType"])
                 ),
-                "window_glazing": get_nullable_value(record["MultipleGlazingType"]),
+                "window_glazing": get_nullable_value(
+                    record_to_insert["MultipleGlazingType"]
+                ),
                 "wall_construction": get_nullable_value(
-                    WALL_CONSTRUCTION_TYPE_MAP.get(record["WallConstruction"])
+                    WALL_CONSTRUCTION_TYPE_MAP.get(record_to_insert["WallConstruction"])
                 ),
                 "wall_insulation": get_nullable_value(
-                    WALL_INSULATION_TYPE_MAP.get(record["WallInsulationType"])
+                    WALL_INSULATION_TYPE_MAP.get(record_to_insert["WallInsulationType"])
                 ),
                 "roof_construction": get_nullable_value(
-                    ROOF_CONSTRUCTION_TYPE_MAP.get(record["RoofConstruction"])
+                    ROOF_CONSTRUCTION_TYPE_MAP.get(record_to_insert["RoofConstruction"])
                 ),
                 "roof_insulation": get_nullable_value(
-                    ROOF_INSULATION_TYPE_MAP.get(record["RoofInsulationLocation"])
+                    ROOF_INSULATION_TYPE_MAP.get(
+                        record_to_insert["RoofInsulationLocation"]
+                    )
                 ),
                 "roof_insulation_thickness": get_nullable_value(
-                    record["RoofInsulationThickness"]
+                    record_to_insert["RoofInsulationThickness"]
                 ),
                 "floor_construction": get_nullable_value(
-                    FLOOR_CONSTRUCTION_TYPE_MAP.get(record["FloorConstruction"])
+                    FLOOR_CONSTRUCTION_TYPE_MAP.get(
+                        record_to_insert["FloorConstruction"]
+                    )
                 ),
                 "floor_insulation": get_nullable_value(
-                    FLOOR_INSULATION_TYPE_MAP.get(record["FloorInsulation"])
+                    FLOOR_INSULATION_TYPE_MAP.get(record_to_insert["FloorInsulation"])
                 ),
             }
+        )
 
-            connection.execute(
-                text(INSERT_EPC_ASSESSMENT_RECORD_QUERY), epc_assessment_record_params
-            )
-            connection.execute(
-                text(INSERT_STRUCTURE_UNIT_RECORD_QUERY), structure_unit_record_params
-            )
+    connection.execute(
+        text(INSERT_EPC_ASSESSMENT_RECORD_QUERY), epc_assessment_records_params
+    )
+    connection.execute(
+        text(INSERT_STRUCTURE_UNIT_RECORD_QUERY), structure_unit_records_params
+    )

--- a/generic-projector/batched_postgres_projector_template.py
+++ b/generic-projector/batched_postgres_projector_template.py
@@ -1,0 +1,150 @@
+# SPDX-License-Identifier: Apache-2.0
+# © Crown Copyright 2025. This work has been developed by the National Digital Twin Programme
+# and is legally attributed to the Department for Business and Trade (UK) as the governing entity.
+
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from json import loads
+
+from dotenv import load_dotenv
+from projection_function import project_func
+from sqlalchemy import create_engine
+from telicent_lib.config import Configurator
+from telicent_lib.records import Record
+
+from custom_projectors.batched_one_off_projector import BatchedOneOffProjector
+
+load_dotenv()
+config = Configurator()
+
+BOOTSTRAP_SERVERS = config.get(
+    "BOOTSTRAP_SERVERS",
+    required=True,
+    description="Specifies the Kafka Bootstrap Servers to connect to.",
+)
+KAFKA_SECURITY_PROTOCOL = config.get(
+    "KAFKA_SECURITY_PROTOCOL",
+    required=False,
+    default="SASL_PLAINTEXT",
+)
+KAFKA_SASL_MECHANISM = config.get(
+    "KAFKA_SASL_MECHANISM",
+    required=False,
+    default="PLAIN",
+)
+SASL_USERNAME = config.get(
+    "SASL_USERNAME",
+    required=True,
+    description="The username for the SASL authentication.",
+)
+SASL_PASSWORD = config.get(
+    "SASL_PASSWORD",
+    required=True,
+    description="The password for the SASL authentication.",
+)
+SOURCE_TOPIC = config.get(
+    "SOURCE_TOPIC",
+    required=True,
+    description="Specifies the Kafka topic the mapper ingests from.",
+)
+
+SOURCE_TOPIC_GROUP_ID = config.get(
+    "SOURCE_TOPIC_GROUP_ID",
+    description="The group id for the topic to consume",
+)
+
+DEBUG = config.get(
+    "DEBUG", required=False, default=False, converter=bool, required_type=bool
+)
+
+LOG_LEVEL = config.get(
+    "LOG_LEVEL",
+    required=False,
+    description="Logging level for the mapper",
+    default="INFO",
+)
+
+DB_HOST = config.get(
+    "DB_HOST",
+    required=True,
+    description="Specifies the host for the database.",
+)
+DB_PORT = config.get(
+    "DB_PORT",
+    required=True,
+    description="Specifies the port for the database.",
+)
+DB_NAME = config.get(
+    "DB_NAME",
+    required=True,
+    description="Specifies the port for the database.",
+)
+DB_USERNAME = config.get(
+    "DB_USERNAME",
+    required=True,
+    description="Specifies the username for the database.",
+)
+DB_PASSWORD = config.get(
+    "DB_PASSWORD",
+    required=True,
+    description="Specifies the password for the database.",
+)
+BATCH_SIZE = config.get(
+    "BATCH_SIZE",
+    required=False,
+    default=25000,
+    description="Size of a batch to project",
+)
+
+kafka_consumer_config = {
+    "bootstrap.servers": BOOTSTRAP_SERVERS,
+    "security.protocol": KAFKA_SECURITY_PROTOCOL,
+    "sasl.mechanism": KAFKA_SASL_MECHANISM,
+    "sasl.username": SASL_USERNAME,
+    "sasl.password": SASL_PASSWORD,
+    "group.id": [SOURCE_TOPIC_GROUP_ID],
+}
+
+kafka_producer_config = {
+    "bootstrap.servers": BOOTSTRAP_SERVERS,
+    "security.protocol": KAFKA_SECURITY_PROTOCOL,
+    "sasl.mechanism": KAFKA_SASL_MECHANISM,
+    "sasl.username": SASL_USERNAME,
+    "sasl.password": SASL_PASSWORD,
+    "allow.auto.create.topics": True,
+}
+
+db_url = (
+    f"postgresql+psycopg2://{DB_USERNAME}:{DB_PASSWORD}@{DB_HOST}:{DB_PORT}/{DB_NAME}"
+)
+
+engine = create_engine(db_url, echo=False, future=True)
+
+
+def unwrap_and_project(records: [Record]) -> None:
+    data = [loads(record.value) for record in records]
+
+    with engine.begin() as conn:
+        project_func(conn, data)
+
+
+projector = BatchedOneOffProjector(
+    SOURCE_TOPIC,
+    kafka_consumer_config,
+    kafka_producer_config,
+    BATCH_SIZE,
+    unwrap_and_project,
+)
+
+projector.run()

--- a/ngd-property-pipeline/Makefile
+++ b/ngd-property-pipeline/Makefile
@@ -8,10 +8,10 @@ docker-run-mapper:
 
 docker-build-projector:
 	cp -r ../custom_projectors projector/
-	cp ../generic-projector/postgres_projector_template.py projector/
+	cp ../generic-projector/batched_postgres_projector_template.py projector/
 	docker build -t ${IMAGE_TAG} -f projector/infrastructure/Dockerfile projector
 	rm -r projector/custom_projectors
-	rm projector/postgres_projector_template.py
+	rm projector/batched_postgres_projector_template.py
 
 docker-run-projector:
 	docker run -d --name os-ngd-building-projector -e BOOTSTRAP_SERVERS=${BOOTSTRAP_SERVERS} -e KAFKA_SECURITY_PROTOCOL=${KAFKA_SECURITY_PROTOCOL} -e KAFKA_SASL_MECHANISM=${KAFKA_SASL_MECHANISM} -e SASL_USERNAME=${SASL_USERNAME} -e SASL_PASSWORD=${SASL_PASSWORD} -e SOURCE_TOPIC=${SOURCE_TOPIC} -e SOURCE_TOPIC_GROUP_ID=${SOURCE_TOPIC_GROUP_ID} -e DB_HOST=${DB_HOST} -e DB_PORT=${DB_PORT} -e DB_USERNAME=${DB_USERNAME} -e DB_PASSWORD=${DB_PASSWORD} -e DB_NAME=${DB_NAME} -e LOG_LEVEL=${LOG_LEVEL} -e DEBUG=${DEBUG} --network "host" ${IMAGE_TAG}

--- a/ngd-property-pipeline/projector/infrastructure/Dockerfile
+++ b/ngd-property-pipeline/projector/infrastructure/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /app
 
 COPY ../custom_projectors ./custom_projectors
 COPY ../src/projection_function.py .
-COPY ../postgres_projector_template.py projector.py
+COPY ../batched_postgres_projector_template.py projector.py
 
 
 COPY ../requirements.txt .

--- a/ngd-property-pipeline/projector/src/projection_function.py
+++ b/ngd-property-pipeline/projector/src/projection_function.py
@@ -115,71 +115,143 @@ def get_nullable_numerical_field(record: dict, field: str):
         return 0
 
 
-def project_func(connection: Connection, record: dict) -> str:
+def project_func(connection: Connection, records: [dict]) -> str:
     """
-    Projects a record into the database
+    Projects a list of records into the database
 
     Args:
-        record (dict): A record representing a building.
+        records ([dict]): A list of records representing a building.
 
     Returns:
         str: The RDF graph serialized into triples.
     """
 
-    uprns = get_uprns(record)
-    for uprn in uprns:
-        params = {
-            "uprn": uprn,
-            "has_roof_solar_panels": has_solar_panels(record),
-            "roof_material": record["roofmaterial_primarymaterial"],
-            "roof_aspect_area_facing_north_m2": get_nullable_numerical_field(
-                record, "roofshapeaspect_areafacingnorth_m2"
-            ),
-            "roof_aspect_area_facing_east_m2": get_nullable_numerical_field(
-                record, "roofshapeaspect_areafacingeast_m2"
-            ),
-            "roof_aspect_area_facing_south_m2": get_nullable_numerical_field(
-                record, "roofshapeaspect_areafacingsouth_m2"
-            ),
-            "roof_aspect_area_facing_west_m2": get_nullable_numerical_field(
-                record, "roofshapeaspect_areafacingwest_m2"
-            ),
-            "roof_aspect_area_facing_north_east_m2": get_nullable_numerical_field(
-                record, "roofshapeaspect_areafacingnortheast_m2"
-            ),
-            "roof_aspect_area_facing_south_east_m2": get_nullable_numerical_field(
-                record, "roofshapeaspect_areafacingsoutheast_m2"
-            ),
-            "roof_aspect_area_facing_south_west_m2": get_nullable_numerical_field(
-                record, "roofshapeaspect_areafacingsouthwest_m2"
-            ),
-            "roof_aspect_area_facing_north_west_m2": get_nullable_numerical_field(
-                record, "roofshapeaspect_areafacingnorthwest_m2"
-            ),
-            "roof_aspect_area_indeterminable_m2": get_nullable_numerical_field(
-                record, "roofshapeaspect_areaindeterminable_m2"
-            ),
-            "roof_shape": record["roofshapeaspect_shape"],
-        }
-        query = None
+    records_to_insert = []
+    records_to_update = []
 
-        existing_epc_record = connection.execute(
-            text(EXISTING_EPC_RECORD_QUERY), {"uprn": uprn}
-        )
-        existing_structure_unit_record = connection.execute(
-            text(EXISTING_STRUCTURE_UNIT_RECORD_QUERY), {"uprn": uprn}
-        )
-        if (
-            existing_epc_record.rowcount > 0
-            or existing_structure_unit_record.rowcount > 0
-        ):
-            query = text(UPDATE_STRUCTURE_UNIT_RECORD_QUERY)
-        else:
-            existing_building_record = connection.execute(
-                text(EXISTING_BUILDING_RECORD_QUERY), {"uprn": uprn}
+    for record in records:
+        uprns = get_uprns(record)
+        uprns_for_update = []
+        uprns_for_insert = []
+        for uprn in uprns:
+            existing_epc_record = connection.execute(
+                text(EXISTING_EPC_RECORD_QUERY), {"uprn": uprn}
             )
-            if existing_building_record.rowcount == 1:
-                query = text(INSERT_STRUCTURE_UNIT_RECORD_QUERY)
+            existing_structure_unit_record = connection.execute(
+                text(EXISTING_STRUCTURE_UNIT_RECORD_QUERY), {"uprn": uprn}
+            )
+            if (
+                existing_epc_record.rowcount > 0
+                and existing_structure_unit_record.rowcount > 0
+            ):
+                uprns_for_update.append(uprn)
+            else:
+                existing_building_record = connection.execute(
+                    text(EXISTING_BUILDING_RECORD_QUERY), {"uprn": uprn}
+                )
+                if existing_building_record.rowcount == 1:
+                    uprns_for_insert.append(uprn)
 
-        if query is not None:
-            connection.execute(query, params)
+        if len(uprns_for_update) > 0:
+            record_copy = record
+            record_copy["uprnreference"] = json.dumps(
+                [{"uprn": uprn_for_update} for uprn_for_update in uprns_for_update]
+            )
+            records_to_update.append(record_copy)
+
+        if len(uprns_for_insert) > 0:
+            record_copy = record
+            record_copy["uprnreference"] = json.dumps(
+                [{"uprn": uprn_for_insert} for uprn_for_insert in uprns_for_insert]
+            )
+            records_to_insert.append(record_copy)
+
+        params_to_insert = []
+
+    for record_to_insert in records_to_insert:
+        uprns = get_uprns(record_to_insert)
+
+        for uprn in uprns:
+            params_to_insert.append(
+                {
+                    "uprn": uprn,
+                    "has_roof_solar_panels": has_solar_panels(record_to_insert),
+                    "roof_material": record_to_insert["roofmaterial_primarymaterial"],
+                    "roof_aspect_area_facing_north_m2": get_nullable_numerical_field(
+                        record_to_insert, "roofshapeaspect_areafacingnorth_m2"
+                    ),
+                    "roof_aspect_area_facing_east_m2": get_nullable_numerical_field(
+                        record_to_insert, "roofshapeaspect_areafacingeast_m2"
+                    ),
+                    "roof_aspect_area_facing_south_m2": get_nullable_numerical_field(
+                        record_to_insert, "roofshapeaspect_areafacingsouth_m2"
+                    ),
+                    "roof_aspect_area_facing_west_m2": get_nullable_numerical_field(
+                        record_to_insert, "roofshapeaspect_areafacingwest_m2"
+                    ),
+                    "roof_aspect_area_facing_north_east_m2": get_nullable_numerical_field(
+                        record_to_insert, "roofshapeaspect_areafacingnortheast_m2"
+                    ),
+                    "roof_aspect_area_facing_south_east_m2": get_nullable_numerical_field(
+                        record_to_insert, "roofshapeaspect_areafacingsoutheast_m2"
+                    ),
+                    "roof_aspect_area_facing_south_west_m2": get_nullable_numerical_field(
+                        record_to_insert, "roofshapeaspect_areafacingsouthwest_m2"
+                    ),
+                    "roof_aspect_area_facing_north_west_m2": get_nullable_numerical_field(
+                        record_to_insert, "roofshapeaspect_areafacingnorthwest_m2"
+                    ),
+                    "roof_aspect_area_indeterminable_m2": get_nullable_numerical_field(
+                        record_to_insert, "roofshapeaspect_areaindeterminable_m2"
+                    ),
+                    "roof_shape": record_to_insert["roofshapeaspect_shape"],
+                }
+            )
+
+    params_to_update = []
+
+    for record_to_update in records_to_update:
+        uprns = get_uprns(records_to_update)
+
+        for uprn in uprns:
+            params_to_update.append(
+                {
+                    "uprn": uprn,
+                    "has_roof_solar_panels": has_solar_panels(record_to_update),
+                    "roof_material": record_to_update["roofmaterial_primarymaterial"],
+                    "roof_aspect_area_facing_north_m2": get_nullable_numerical_field(
+                        record_to_update, "roofshapeaspect_areafacingnorth_m2"
+                    ),
+                    "roof_aspect_area_facing_east_m2": get_nullable_numerical_field(
+                        record_to_update, "roofshapeaspect_areafacingeast_m2"
+                    ),
+                    "roof_aspect_area_facing_south_m2": get_nullable_numerical_field(
+                        record_to_update, "roofshapeaspect_areafacingsouth_m2"
+                    ),
+                    "roof_aspect_area_facing_west_m2": get_nullable_numerical_field(
+                        record_to_update, "roofshapeaspect_areafacingwest_m2"
+                    ),
+                    "roof_aspect_area_facing_north_east_m2": get_nullable_numerical_field(
+                        record_to_update, "roofshapeaspect_areafacingnortheast_m2"
+                    ),
+                    "roof_aspect_area_facing_south_east_m2": get_nullable_numerical_field(
+                        record_to_update, "roofshapeaspect_areafacingsoutheast_m2"
+                    ),
+                    "roof_aspect_area_facing_south_west_m2": get_nullable_numerical_field(
+                        record_to_update, "roofshapeaspect_areafacingsouthwest_m2"
+                    ),
+                    "roof_aspect_area_facing_north_west_m2": get_nullable_numerical_field(
+                        record_to_update, "roofshapeaspect_areafacingnorthwest_m2"
+                    ),
+                    "roof_aspect_area_indeterminable_m2": get_nullable_numerical_field(
+                        record_to_update, "roofshapeaspect_areaindeterminable_m2"
+                    ),
+                    "roof_shape": record_to_update["roofshapeaspect_shape"],
+                }
+            )
+
+    if len(params_to_update) > 0:
+        connection.execute(text(UPDATE_STRUCTURE_UNIT_RECORD_QUERY), params_to_update)
+
+    if len(params_to_insert) > 0:
+        connection.execute(text(INSERT_STRUCTURE_UNIT_RECORD_QUERY), params_to_insert)


### PR DESCRIPTION
## Sensitive Credential Checks
- [x] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [ ] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The current way the projectors are run is sequential processing single record and for each record a new connection is opened to the db and a new commit/rollback is made at the end depending on success or failure of the script. This creates overhead and could lead to slower processing times.

## Description
<!--- Describe your changes in detail -->
- Added batched postgres projector template
- Changed EPC projector to the batched postgres projector template
- Changed the OS NGD building projector to the batched postgres projector template

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran. -->
<!--- How does your change affect other areas of the code, etc. -->
Tested locally and is working as expected

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [x] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.